### PR TITLE
Adding the --print-version and -V flags

### DIFF
--- a/cargo-quickinstall/src/args.rs
+++ b/cargo-quickinstall/src/args.rs
@@ -5,6 +5,7 @@ pub struct CliOptions {
     pub target: Option<String>,
     pub crate_name: Option<String>,
     pub fallback: bool,
+    pub print_version: bool,
 }
 
 pub fn options_from_args(
@@ -14,6 +15,7 @@ pub fn options_from_args(
         version: args.opt_value_from_str("--version")?,
         target: args.opt_value_from_str("--target")?,
         fallback: !args.contains("--no-fallback"),
+        print_version: args.contains(["-V", "--print-version"]),
         // WARNING: We MUST parse all --options before parsing positional arguments,
         // because .subcommand() errors out if handed an arg with - at the start.
         crate_name: crate_name_from_positional_args(args)?,

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -320,6 +320,14 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 
     let options = args::options_from_args(args)?;
 
+    if options.print_version {
+        println!(
+            "`cargo quickinstall` version: {}",
+            env!("CARGO_PKG_VERSION")
+        );
+        return Ok(());
+    }
+
     let crate_name = options.crate_name.ok_or(args::USAGE)?;
     let version = match options.version {
         Some(version) => version,


### PR DESCRIPTION
These two flags are equivalent.  They print quickinstall's own version.

Closes #20 