### PR TITLE
The --dry-run flag

### DIFF
--- a/cargo-quickinstall/src/args.rs
+++ b/cargo-quickinstall/src/args.rs
@@ -10,6 +10,7 @@ OPTIONS:
         --version <VERSION>         Specify a version to install
         --target <TRIPLE>           Install package for the target triple
         --no-fallback               Don't fall back to `cargo install`
+        --dry-run                   Print the \"curl | tar\" command that would be run to fetch the binary
     -V, --print-version             Print version info and exit
     -h, --help                      Prints help information
 ";
@@ -21,6 +22,7 @@ pub struct CliOptions {
     pub fallback: bool,
     pub print_version: bool,
     pub help: bool,
+    pub dry_run: bool,
 }
 
 pub fn options_from_env() -> Result<CliOptions, Box<dyn std::error::Error + Send + Sync + 'static>>
@@ -32,6 +34,7 @@ pub fn options_from_env() -> Result<CliOptions, Box<dyn std::error::Error + Send
         fallback: !args.contains("--no-fallback"),
         print_version: args.contains(["-V", "--print-version"]),
         help: args.contains(["-h", "--help"]),
+        dry_run: args.contains("--dry-run"),
         // WARNING: We MUST parse all --options before parsing positional arguments,
         // because .subcommand() errors out if handed an arg with - at the start.
         crate_name: crate_name_from_positional_args(args)?,

--- a/cargo-quickinstall/src/args.rs
+++ b/cargo-quickinstall/src/args.rs
@@ -10,7 +10,7 @@ OPTIONS:
         --version <VERSION>         Specify a version to install
         --target <TRIPLE>           Install package for the target triple
         --no-fallback               Don't fall back to `cargo install`
-        --dry-run                   Print the \"curl | tar\" command that would be run to fetch the binary
+        --dry-run                   Print the `curl | tar` command that would be run to fetch the binary
     -V, --print-version             Print version info and exit
     -h, --help                      Prints help information
 ";

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -339,6 +339,11 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         None => get_target_triple()?,
     };
 
+    if options.dry_run {
+        println!("[Dry run] curl --user-agent \"cargo-quickinstall client (alsuren@gmail.com)\" --location --silent --show-error --fail https://github.com/alsuren/cargo-quickinstall/releases/download/{crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz | tar -xzvvf - -C ~/.cargo/bin", crate_name=crate_name, version=version, target=target);
+        return Ok(());
+    }
+
     let details = CrateDetails {
         crate_name,
         version,

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -340,7 +340,18 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     };
 
     if options.dry_run {
-        println!("[Dry run] curl --user-agent \"cargo-quickinstall client (alsuren@gmail.com)\" --location --silent --show-error --fail https://github.com/alsuren/cargo-quickinstall/releases/download/{crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz | tar -xzvvf - -C ~/.cargo/bin", crate_name=crate_name, version=version, target=target);
+        let cargo_bin_dir = home::cargo_home().unwrap().join("bin");
+        println!(
+            "curl --user-agent \"cargo-quickinstall client (alsuren@gmail.com)\" \
+                 --location --silent --show-error --fail \
+                 https://github.com/alsuren/cargo-quickinstall/releases/download/\
+                 {crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz | \
+                 tar -xzvvf - -C {cargo_bin_dir}",
+            crate_name = crate_name,
+            version = version,
+            target = target,
+            cargo_bin_dir = cargo_bin_dir.to_str().unwrap()
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
The ```--dry-run``` flag prints just the "curl | tar" command run during the happy path scenario where a pre-built crate binary is already available.

Closes #64 