### PR TITLE
feat(build): binary opt using codegen-units

### DIFF
--- a/build-version.sh
+++ b/build-version.sh
@@ -26,14 +26,14 @@ then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; cargo install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; RUSTFLAGS=\"$RUSTFLAGS -C codegen-units=1\" cargo install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"
     CRATES2_JSON_PATH="${TEMPDIR}/cargo/.crates2.json"
 else
     rustup target add "$TARGET_ARCH"
-    cargo install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH"
+    RUSTFLAGS="$RUSTFLAGS -C codegen-units=1" cargo install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH"
 
     CARGO_BIN_DIR=~/.cargo/bin
     CRATES2_JSON_PATH=~/.cargo/.crates2.json


### PR DESCRIPTION
This would be an "easy" addition to optimize some binaries.

By default `codegen-units` is set to `16`, this could do it just all at once over everthing.

Additional binary opt flags:
 - `strip` affects what symbols are found in the binary
 - `lto` for link time optimizations (didn't get it working)

Quickly tested it on 2 crates you seem to build, I explicitly chose 2 smaller crates as they should show to effect in even small cases. the following byte measures are from `stat --printf="%s" xyz`
 - `cargo-all-features` (specificall `cargo-build-all-features`)
    - No flags # 4'041'456 bytes
    - `-C codegen-units=1` # 3'982'752 bytes
    - `-C codegen-units=1 -C strip="symbols"` # 497'984 bytes
- `minifier` (one you've just added)
    - No flags # 362'816 bytes
    - `-C codegen-units=1` # 362'816 bytes
    - `-C codegen-units=1 -C strip="symbols"` # 362'816 bytes

Now minifier is very very (and I can't stress this enough) very small crate with only 2 dependencies and some hunderd lines of code. But `cargo-all-features` shows that there can be a difference in size.

To point this out clearly, these flags are usually used to have some small perf gains. (which yes, it does)

So whats the down side? Build time. You have longer builds to be faster at execution.

Why not `strip`? I'm personally not sure about this. `cargo-all-features` seems to benefit well from it interms of size, but loosing symbols might be counter productive. Then again, if one would like to control them, they could provide binaries themselves and an almost 10x reduction in size is huge, not only for execution but also for downloads speed and the amount of transfer happening.

It's a simple proposal, but I'm happy to hear your opinion
