### PR TITLE
fix(build-opt): use CARGO_PROFILE_ env vars for build opt

### DIFF
--- a/build-version.sh
+++ b/build-version.sh
@@ -26,14 +26,14 @@ then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; RUSTFLAGS=\"$RUSTFLAGS -C codegen-units=1\" cargo install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" cargo install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"
     CRATES2_JSON_PATH="${TEMPDIR}/cargo/.crates2.json"
 else
     rustup target add "$TARGET_ARCH"
-    RUSTFLAGS="$RUSTFLAGS -C codegen-units=1" cargo install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH"
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" cargo install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH"
 
     CARGO_BIN_DIR=~/.cargo/bin
     CRATES2_JSON_PATH=~/.cargo/.crates2.json


### PR DESCRIPTION
The followup on #80 

That LTO thing had me bugging during lunch. And I totally forgot about the env flags cargo reads https://doc.rust-lang.org/cargo/reference/environment-variables.html

This unifies the syntax for flags used, enables lto and makes sure what ever `cargo` changes, it does not affect what `RUSTFLAGS` are provided as it is totally handled by `cargo`