### PR TITLE
revoke permissions for builder

### DIFF
--- a/.github/workflows/build-package.yml.template
+++ b/.github/workflows/build-package.yml.template
@@ -13,6 +13,7 @@ jobs:
   build-popular-package:
     name: Build
     runs-on: $BUILD_OS
+    permissions: {}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
I think that this solves https://github.com/alsuren/cargo-quickinstall/issues/49 without any added complexity. 

I stumbled across this setting when trying to set up the webhook based scheme described in #49.
The paper trail went something like: https://github.com/organizations/cargo-quick/settings/actions
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token

This allowed me to know that it was possible at the top level, and then I jumped into vscode to see whether it was possible to use it at the job level (using the red hat yaml plugin, which pointed me at https://json.schemastore.org/github-workflow.json)

Turns out it is: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions