### PR TITLE
tar defaults to format=gnu, whose sparse extension breaks the tar crate

### DIFF
--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -31,7 +31,7 @@ jobs:
               --fail "https://crates.io/api/v1/crates/cargo-quickinstall" \
               | jq -r .versions[0].num
           )
-          env ALWAYS_BUILD=1 VERSION=$VERSION TARGET_ARCH=TARGET_ARCH=$(rustc --version --verbose | sed -n 's/host: //p') ./build-version.sh cargo-quickinstall
+          env ALWAYS_BUILD=1 VERSION=$VERSION TARGET_ARCH="$(rustc --version --verbose | sed -n 's/host: //p')" ./build-version.sh cargo-quickinstall
       - name: Install Thyself
         run: cargo install --path cargo-quickinstall
       - name: Install Thyself with Thyself (or fallback to sensei on windows)

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -15,6 +15,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
+        # FIXME: add cross-compilation targets to this matrix somehow
         os: [macos-latest, ubuntu-20.04, windows-latest]
     steps:
       - uses: actions/checkout@v2
@@ -22,7 +23,7 @@ jobs:
           persist-credentials: false
       - name: Build Thyself
         run: |
-          set -euo pipefail
+          set -euxo pipefail
           touch .env
           VERSION=$(
             curl \
@@ -30,8 +31,7 @@ jobs:
               --fail "https://crates.io/api/v1/crates/cargo-quickinstall" \
               | jq -r .versions[0].num
           )
-          env VERSION=$VERSION TARGET_ARCH=x86_64-unknown-linux-gnu ./build-version.sh cargo-quickinstall
-          # FIXME: re-enable uploading code here.
+          env ALWAYS_BUILD=1 VERSION=$VERSION TARGET_ARCH=x86_64-unknown-linux-gnu ./build-version.sh cargo-quickinstall
       - name: Install Thyself
         run: cargo install --path cargo-quickinstall
       - name: Install Thyself with Thyself (or fallback to sensei on windows)

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -31,7 +31,7 @@ jobs:
               --fail "https://crates.io/api/v1/crates/cargo-quickinstall" \
               | jq -r .versions[0].num
           )
-          env ALWAYS_BUILD=1 VERSION=$VERSION TARGET_ARCH=x86_64-unknown-linux-gnu ./build-version.sh cargo-quickinstall
+          env ALWAYS_BUILD=1 VERSION=$VERSION TARGET_ARCH=TARGET_ARCH=$(rustc --version --verbose | sed -n 's/host: //p') ./build-version.sh cargo-quickinstall
       - name: Install Thyself
         run: cargo install --path cargo-quickinstall
       - name: Install Thyself with Thyself (or fallback to sensei on windows)

--- a/build-version.sh
+++ b/build-version.sh
@@ -57,6 +57,6 @@ done
 #
 # TODO: maybe we want to make a ~/.cargo-quickinstall/bin to untar into,
 # and add symlinks into ~/.cargo/bin, to aid debugging?
-tar -czf "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz" $BINARIES
+tar --posix -czf "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz" $BINARIES
 
 echo "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"

--- a/build-version.sh
+++ b/build-version.sh
@@ -57,6 +57,6 @@ done
 #
 # TODO: maybe we want to make a ~/.cargo-quickinstall/bin to untar into,
 # and add symlinks into ~/.cargo/bin, to aid debugging?
-tar --portability -czf "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz" $BINARIES
+tar --format=v7 -czf "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz" $BINARIES
 
 echo "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"

--- a/build-version.sh
+++ b/build-version.sh
@@ -57,6 +57,6 @@ done
 #
 # TODO: maybe we want to make a ~/.cargo-quickinstall/bin to untar into,
 # and add symlinks into ~/.cargo/bin, to aid debugging?
-tar --posix -czf "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz" $BINARIES
+tar --portability -czf "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz" $BINARIES
 
 echo "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"

--- a/build-version.sh
+++ b/build-version.sh
@@ -16,7 +16,7 @@ curl_slowly() {
     sleep 1 && curl --user-agent "cargo-quickinstall build pipeline (alsuren@gmail.com)" "$@"
 }
 
-if curl_slowly --fail -I --output /dev/null "https://github.com/alsuren/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
+if [ "$ALWAYS_BUILD" != 1 ] && curl_slowly --fail -I --output /dev/null "https://github.com/alsuren/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
     echo "${CRATE}/${VERSION}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz already uploaded. Skipping."
     exit 0
 fi


### PR DESCRIPTION
See https://github.com/alsuren/cargo-quickinstall/issues/87 for discussion.